### PR TITLE
Return ownerID as part of GetLB

### DIFF
--- a/pkg/lbapi/client_test.go
+++ b/pkg/lbapi/client_test.go
@@ -17,6 +17,7 @@ func newGQLClientMock() *mock.GQLClient {
 		if ok {
 			lb.LoadBalancer.ID = "loadbal-test"
 			lb.LoadBalancer.Name = "test"
+			lb.LoadBalancer.Owner.ID = "testtnt-test"
 		}
 
 		return nil
@@ -41,4 +42,5 @@ func TestGetLoadBalancer(t *testing.T) {
 
 	assert.Equal(t, lb.LoadBalancer.ID, "loadbal-test")
 	assert.Equal(t, lb.LoadBalancer.Name, "test")
+	assert.Equal(t, lb.LoadBalancer.Owner.ID, "testtnt-test")
 }

--- a/pkg/lbapi/types.go
+++ b/pkg/lbapi/types.go
@@ -38,8 +38,13 @@ type Ports struct {
 	Edges []PortEdges
 }
 
+type OwnerNode struct {
+	ID string
+}
+
 type LoadBalancer struct {
 	ID    string
+	Owner OwnerNode
 	Name  string
 	Ports Ports
 }
@@ -52,6 +57,7 @@ type GetLoadBalancer struct {
 // type GetLoadBalancer struct {
 // 	LoadBalancer struct {
 // 		ID    string
+//      Owner string
 // 		Name  string
 // 		Ports struct {
 // 			Edges []struct {


### PR DESCRIPTION
Returns the ownerID as part of the GetLoadBalancer query in the API client