### PR TITLE
Add Validation to Prevent Private IPs in Haproxy Server Blocks

### DIFF
--- a/internal/manager/errors.go
+++ b/internal/manager/errors.go
@@ -23,6 +23,9 @@ var (
 
 	// errBackendServerFailure is returned when a server cannot be applied to a backend
 	errBackendServerFailure = errors.New("failed to add backend attr server: ")
+
+	// errServerPrivateIPInvalid is returned when a private origin target ip is provided
+	errServerPrivateIPInvalid = errors.New("origin target is in a private ip range")
 )
 
 func newLabelError(label string, err error, labelErr error) error {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -217,8 +217,7 @@ func (m *Manager) mergeConfig(cfg parser.Parser, lb *lbapi.LoadBalancer) (parser
 		for _, pool := range p.Node.Pools {
 			for _, origin := range pool.Origins.Edges {
 				if isPrivateIP(origin.Node.Target) {
-					m.Logger.Warnf("private ip address not allowed, target: %s, portId: ", origin.Node.Target, p.Node.ID)
-					continue
+					return nil, fmt.Errorf("error: %w, ip: %s", errServerPrivateIPInvalid, origin.Node.Target)
 				}
 
 				srvAddr := fmt.Sprintf("%s:%d check port %d", origin.Node.Target, origin.Node.PortNumber, origin.Node.PortNumber)

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -31,6 +31,11 @@ const (
 )
 
 func TestMergeConfig(t *testing.T) {
+	l, err := zap.NewDevelopmentConfig().Build()
+	logger := l.Sugar()
+
+	require.Nil(t, err)
+
 	MergeConfigTests := []struct {
 		name                string
 		testInput           lbapi.LoadBalancer
@@ -48,10 +53,14 @@ func TestMergeConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			mgr := Manager{
+				Logger: logger,
+			}
+
 			cfg, err := parser.New(options.Path("../../.devcontainer/config/haproxy.cfg"), options.NoNamedDefaultsFrom)
 			require.Nil(t, err)
 
-			newCfg, err := mergeConfig(cfg, &tt.testInput)
+			newCfg, err := mgr.mergeConfig(cfg, &tt.testInput)
 			assert.Nil(t, err)
 
 			t.Log("Generated config ===> ", newCfg.String())

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -324,36 +324,6 @@ func TestUpdateConfigToLatest(t *testing.T) {
 															Active:     false,
 														},
 													},
-													{ // private ip will be skipped
-														Node: lbapi.OriginNode{
-															ID:         "loadogn-test5",
-															Name:       "svr2",
-															Target:     "172.16.0.0",
-															PortNumber: 2222,
-															Weight:     50,
-															Active:     false,
-														},
-													},
-													{ // private ip will be skipped
-														Node: lbapi.OriginNode{
-															ID:         "loadogn-test6",
-															Name:       "svr2",
-															Target:     "192.168.0.0",
-															PortNumber: 2222,
-															Weight:     50,
-															Active:     false,
-														},
-													},
-													{ // private ip will be skipped
-														Node: lbapi.OriginNode{
-															ID:         "loadogn-test7",
-															Name:       "svr2",
-															Target:     "fc00:db8:3333:4444:5555:6666:7777:8888",
-															PortNumber: 2222,
-															Weight:     50,
-															Active:     false,
-														},
-													},
 												},
 											},
 										},
@@ -384,12 +354,7 @@ func TestUpdateConfigToLatest(t *testing.T) {
 		}
 
 		err := mgr.updateConfigToLatest()
-		require.Nil(t, err)
-
-		expCfg, err := os.ReadFile(fmt.Sprintf("%s/%s", testDataBaseDir, "lb-ex-1-exp.cfg"))
-		require.Nil(t, err)
-
-		assert.Equal(t, strings.TrimSpace(string(expCfg)), strings.TrimSpace(mgr.currentConfig))
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
We do not want users to be able to add private ips as backends in the haproxy config