### PR TITLE
Update Origin Server Naming in HAProxy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,16 +5,13 @@ linters-settings:
 linters:
   enable:
     # default linters
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
     # additional linters
     - bodyclose

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -223,7 +223,7 @@ func mergeConfig(cfg parser.Parser, lb *lbapi.LoadBalancer) (parser.Parser, erro
 				}
 
 				srvr := types.Server{
-					Name:    origin.Node.ID,
+					Name:    fmt.Sprintf("%s::%s", origin.Node.ID, origin.Node.Target),
 					Address: srvAddr,
 				}
 

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -368,6 +368,7 @@ func TestProcessMsg(t *testing.T) {
 			if tt.errMsg != "" {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tt.errMsg)
+
 				return
 			}
 

--- a/internal/manager/testdata/lb-ex-1-exp.cfg
+++ b/internal/manager/testdata/lb-ex-1-exp.cfg
@@ -27,9 +27,9 @@ frontend stats
   http-request use-service prometheus-exporter if { path /metrics }
 
 backend loadprt-test
-  server loadogn-test1 1.2.3.4:2222 check port 2222 weight 20
-  server loadogn-test2 1.2.3.4:222 check port 222 weight 30
-  server loadogn-test3 4.3.2.1:2222 check port 2222 weight 50 disabled
+  server loadogn-test1::1.2.3.4 1.2.3.4:2222 check port 2222 weight 20
+  server loadogn-test2::1.2.3.4 1.2.3.4:222 check port 222 weight 30
+  server loadogn-test3::4.3.2.1 4.3.2.1:2222 check port 2222 weight 50 disabled
 
 program dataplaneapi
   command dataplaneapi -f /bitnami/haproxy/conf/dataplaneapi.yaml

--- a/internal/manager/testdata/lb-ex-2-exp.cfg
+++ b/internal/manager/testdata/lb-ex-2-exp.cfg
@@ -27,10 +27,10 @@ frontend stats
   http-request use-service prometheus-exporter if { path /metrics }
 
 backend loadprt-test
-  server loadogn-test1 1.2.3.4:2222 check port 2222 weight 20
-  server loadogn-test2 1.2.3.4:222 check port 222 weight 30
-  server loadogn-test3 4.3.2.1:2222 check port 2222 weight 50 disabled
-  server loadogn-test4 7.8.9.0:2222 check port 2222 weight 100
+  server loadogn-test1::1.2.3.4 1.2.3.4:2222 check port 2222 weight 20
+  server loadogn-test2::1.2.3.4 1.2.3.4:222 check port 222 weight 30
+  server loadogn-test3::4.3.2.1 4.3.2.1:2222 check port 2222 weight 50 disabled
+  server loadogn-test4::7.8.9.0 7.8.9.0:2222 check port 2222 weight 100
 
 program dataplaneapi
   command dataplaneapi -f /bitnami/haproxy/conf/dataplaneapi.yaml

--- a/internal/manager/testdata/lb-ex-3-exp.cfg
+++ b/internal/manager/testdata/lb-ex-3-exp.cfg
@@ -31,10 +31,10 @@ frontend stats
   http-request use-service prometheus-exporter if { path /metrics }
 
 backend loadprt-testhttp
-  server loadogn-test1 3.1.4.1:80 check port 80 weight 1
+  server loadogn-test1::3.1.4.1 3.1.4.1:80 check port 80 weight 1
 
 backend loadprt-testhttps
-  server loadogn-test2 3.1.4.1:443 check port 443 weight 90
+  server loadogn-test2::3.1.4.1 3.1.4.1:443 check port 443 weight 90
 
 program dataplaneapi
   command dataplaneapi -f /bitnami/haproxy/conf/dataplaneapi.yaml


### PR DESCRIPTION
This change allows for an easier time parsing metrics from prometheus.

For example: `haproxy_server_bytes_in_total` from https://www.haproxy.com/documentation/haproxy-configuration-tutorials/alerts-and-monitoring/prometheus/